### PR TITLE
[#21]implement our own conf class

### DIFF
--- a/app/utils/PenguinConf.scala
+++ b/app/utils/PenguinConf.scala
@@ -1,0 +1,15 @@
+package utils
+
+import com.typesafe.config.ConfigFactory
+
+object PenguinConf {
+  private def get(key: String): String = ConfigFactory.load.getString(key)
+  object AWS {
+    object S3 {
+      def accessKey: String = get("aws.s3.accessKey")
+      def secretKey: String = get("aws.s3.secretKey")
+      def endpoint: String  = get("aws.s3.endpoint")
+      def bucket: String    = get("aws.s3.bucket")
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,3 +3,8 @@ db.default.driver=com.mysql.cj.jdbc.Driver
 db.default.url="jdbc:mysql://penguin-mysql/penguinhouse"
 db.default.username=penguin
 db.default.password="penguin"
+
+aws.s3.accessKey="penguinhouse"
+aws.s3.secretKey="penguinhouse"
+aws.s3.endpoint="http://s3:9000"
+aws.s3.bucket="penguin"

--- a/test/utils/PenguinConfSpec.scala
+++ b/test/utils/PenguinConfSpec.scala
@@ -1,0 +1,25 @@
+package utils
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.test.Helpers.status
+
+class PenguinConfSpec extends PlaySpec with GuiceOneAppPerTest{
+  "PenguinConf AWS.S3" must {
+    "can get accessKey" in {
+      PenguinConf.AWS.S3.accessKey mustBe "penguinhouse"
+    }
+
+    "can get secretKey" in {
+      PenguinConf.AWS.S3.accessKey mustBe "penguinhouse"
+    }
+
+    "can get endpoint" in {
+      PenguinConf.AWS.S3.accessKey mustBe "http://s3:9000"
+    }
+
+    "can get bucket" in {
+      PenguinConf.AWS.S3.accessKey mustBe "penguin"
+    }
+  }
+}

--- a/test/utils/PenguinConfSpec.scala
+++ b/test/utils/PenguinConfSpec.scala
@@ -6,20 +6,20 @@ import play.api.test.Helpers.status
 
 class PenguinConfSpec extends PlaySpec with GuiceOneAppPerTest{
   "PenguinConf AWS.S3" must {
-    "can get accessKey" in {
+    "get accessKey" in {
       PenguinConf.AWS.S3.accessKey mustBe "penguinhouse"
     }
 
-    "can get secretKey" in {
-      PenguinConf.AWS.S3.accessKey mustBe "penguinhouse"
+    "get secretKey" in {
+      PenguinConf.AWS.S3.secretKey mustBe "penguinhouse"
     }
 
-    "can get endpoint" in {
-      PenguinConf.AWS.S3.accessKey mustBe "http://s3:9000"
+    "get endpoint" in {
+      PenguinConf.AWS.S3.endpoint mustBe "http://s3:9000"
     }
 
-    "can get bucket" in {
-      PenguinConf.AWS.S3.accessKey mustBe "penguin"
+    "get bucket" in {
+      PenguinConf.AWS.S3.bucket mustBe "penguin"
     }
   }
 }


### PR DESCRIPTION
resolve #21 .

## Major changes
Implement our own config class

## Memo
Without this class, we can't use config values type-safely because we have to access config values using the keys of properties.